### PR TITLE
Add API integration guide

### DIFF
--- a/API_INTEGRATION.md
+++ b/API_INTEGRATION.md
@@ -1,0 +1,162 @@
+# SiemensX API Integration Guide
+
+This document explains how frontend developers can interact with the SiemensX backend.
+All endpoints return JSON and expect the `Content-Type: application/json` header when
+sending a body.
+
+The API root is the directory where the PHP project is hosted. If running locally
+with `php -S localhost:8000` then the base URL is `http://localhost:8000`.
+
+Most endpoints require authentication via a bearer token obtained during login or
+registration. Include the header:
+
+```
+Authorization: Bearer <token>
+```
+
+## Authentication
+
+### `POST /api/auth/register.php`
+Create a new user.
+
+**Request JSON**
+```json
+{
+  "full_name": "John Smith",
+  "username": "jsmith",
+  "email": "jsmith@example.com",
+  "password": "secret",
+  "referred_by": 1      // optional user id
+}
+```
+
+**Response**
+```json
+{
+  "token": "<api_token>",
+  "user_id": 12
+}
+```
+
+### `POST /api/auth/login.php`
+Log in with username or email and password.
+
+**Request JSON**
+```json
+{
+  "username": "jsmith",
+  "password": "secret"
+}
+```
+
+**Response**
+```json
+{
+  "token": "<api_token>"
+}
+```
+
+## User
+
+### `GET /api/user/get_profile.php`
+Return the authenticated user's profile.
+
+### `POST /api/user/update.php`
+Update `full_name` or `email`.
+
+**Request JSON**
+```json
+{
+  "full_name": "New Name",
+  "email": "new@example.com"
+}
+```
+
+### `GET /api/user/earnings.php`
+Return total referral earnings for the logged in user.
+
+## Deposits
+
+### `POST /api/deposits/request.php`
+Request a new deposit.
+
+**Request JSON**
+```json
+{
+  "amount": 100,
+  "method": "bank"
+}
+```
+
+### `GET /api/deposits/history.php`
+List the user's past deposit requests.
+
+## Withdrawals
+
+### `POST /api/withdrawals/request.php`
+Request a withdrawal.
+
+**Request JSON**
+```json
+{
+  "amount": 50,
+  "wallet_address": "0x123...",
+  "method": "crypto"
+}
+```
+
+### `GET /api/withdrawals/history.php`
+List withdrawal requests made by the user.
+
+## Transactions
+
+### `GET /api/transactions/history.php`
+Return the account's transaction log.
+
+## Referrals
+
+### `GET /api/referrals/earnings.php`
+List individual referral earnings entries.
+
+## Admin Endpoints
+(Admin token required)
+
+### `GET /api/admin/dashboard_stats.php`
+Return counts of users and pending requests.
+
+### `POST /api/admin/approve_deposit.php`
+Approve or reject a deposit request.
+
+**Request JSON**
+```json
+{
+  "id": 5,
+  "status": "approved"   // or "rejected"
+}
+```
+
+### `POST /api/admin/approve_withdrawal.php`
+Approve or reject a withdrawal request.
+
+**Request JSON**
+```json
+{
+  "id": 2,
+  "status": "approved"
+}
+```
+
+### `POST /api/admin/broadcast_email.php`
+Send a message to all users.
+
+**Request JSON**
+```json
+{
+  "subject": "News",
+  "message": "Hello everyone"
+}
+```
+
+---
+
+For additional details on environment setup or deployment see `README.md`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# apisiemensx
+# SiemensX PHP Backend
+
+This project provides a simple RESTful backend for the **SiemensX** platform built with pure PHP and MySQL. It exposes JSON endpoints for user management, deposits, withdrawals, referrals and admin features.
+
+## Requirements
+- PHP 8.x or later
+- MySQL
+
+## Setup
+1. Create a MySQL database called `siemensx` (or any name you prefer) and import `db.sql` located in the repository root.
+2. Edit `config/db.php` and update `$DB_HOST`, `$DB_USER`, `$DB_PASS`, and `$DB_NAME` with your database settings.
+3. Ensure the `uploads/` directories are writable by the web server so uploaded receipt and profile images can be stored.
+4. (Optional) Create an admin user directly in the database table `admins` so you can access admin endpoints.
+
+## Running Locally
+Launch PHP's built-in server from the project root:
+```bash
+php -S localhost:8000
+```
+The API will be accessible at `http://localhost:8000`.
+
+## Deployment Notes
+To deploy in production you can use Apache or Nginx with PHP-FPM:
+1. Copy the project files to your server.
+2. Point your web server's document root to the repository directory.
+3. Configure a virtual host so all requests under `/api/` are served by PHP. A basic Apache config might look like:
+```apache
+<VirtualHost *:80>
+    DocumentRoot /var/www/siemensx
+    <Directory /var/www/siemensx>
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+```
+4. Restart your web server and verify the API endpoints respond.
+
+Make sure to keep `uploads/` protected by the provided `.htaccess` files to prevent executing uploaded content.
+
+## Folder Structure
+```
+/api
+  /auth          Authentication endpoints
+  /admin         Admin-only endpoints
+  /deposits      Deposit requests and history
+  /withdrawals   Withdrawal requests and history
+  /referrals     Referral earnings
+  /transactions  Transaction history
+  /user          Profile actions
+/config          Database and CORS config
+/helpers        Utility helpers
+/middleware     Authentication middleware
+/uploads/       Uploaded files (protected by .htaccess)
+```
+
+## Example Endpoints
+- `POST /api/auth/register.php`
+- `POST /api/auth/login.php`
+- `GET  /api/user/get_profile.php` (requires Authorization header)
+- `POST /api/deposits/request.php`
+- `GET  /api/admin/dashboard_stats.php` (admin token required)
+
+All responses are JSON. For protected routes include `Authorization: Bearer <token>`.
+For detailed endpoint descriptions see **API_INTEGRATION.md**.

--- a/api/admin/approve_deposit.php
+++ b/api/admin/approve_deposit.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../../middleware/admin_auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$deposit_id = $input['id'] ?? 0;
+$status = $input['status'] ?? '';
+if (!$deposit_id || !in_array($status, ['approved','rejected'])) {
+    send_json(['error' => 'Invalid payload'], 400);
+}
+
+
+$stmt = $pdo->prepare('SELECT user_id, amount, status FROM deposits WHERE id=?');
+$stmt->execute([$deposit_id]);
+$deposit = $stmt->fetch();
+if (!$deposit) {
+    send_json(['error' => 'Deposit not found'], 404);
+}
+
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('UPDATE deposits SET status=? WHERE id=?');
+$stmt->execute([$status, $deposit_id]);
+
+if ($status === 'approved' && $deposit['status'] !== 'approved') {
+    $stmt = $pdo->prepare('UPDATE users SET balance = balance + ? WHERE id=?');
+    $stmt->execute([$deposit['amount'], $deposit['user_id']]);
+    $stmt = $pdo->prepare('INSERT INTO transactions (action, credit, userId) VALUES ("deposit", ?, ?)');
+    $stmt->execute([$deposit['amount'], $deposit['user_id']]);
+}
+
+$pdo->commit();
+
+send_json(['message' => 'Deposit updated']);
+?>

--- a/api/admin/approve_withdrawal.php
+++ b/api/admin/approve_withdrawal.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../../middleware/admin_auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$withdrawal_id = $input['id'] ?? 0;
+$status = $input['status'] ?? '';
+if (!$withdrawal_id || !in_array($status, ['approved','rejected'])) {
+    send_json(['error' => 'Invalid payload'], 400);
+}
+
+
+$stmt = $pdo->prepare('SELECT user_id, amount, status FROM withdrawals WHERE id=?');
+$stmt->execute([$withdrawal_id]);
+$withdrawal = $stmt->fetch();
+if (!$withdrawal) {
+    send_json(['error' => 'Withdrawal not found'], 404);
+}
+
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('UPDATE withdrawals SET status=?, processed_by=?, processed_at=NOW() WHERE id=?');
+$stmt->execute([$status, $admin['id'], $withdrawal_id]);
+
+if ($status === 'approved' && $withdrawal['status'] !== 'approved') {
+    $stmt = $pdo->prepare('UPDATE users SET balance = balance - ? WHERE id=?');
+    $stmt->execute([$withdrawal['amount'], $withdrawal['user_id']]);
+    $stmt = $pdo->prepare('INSERT INTO transactions (action, debit, userId) VALUES ("withdrawal", ?, ?)');
+    $stmt->execute([$withdrawal['amount'], $withdrawal['user_id']]);
+}
+
+$pdo->commit();
+
+send_json(['message' => 'Withdrawal updated']);
+?>

--- a/api/admin/broadcast_email.php
+++ b/api/admin/broadcast_email.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../../middleware/admin_auth.php';
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../helpers/mail.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$subject = $input['subject'] ?? '';
+$message = $input['message'] ?? '';
+if (!$subject || !$message) {
+    send_json(['error' => 'Invalid payload'], 400);
+}
+
+$users = $pdo->query('SELECT email FROM users')->fetchAll();
+$emails = [];
+foreach ($users as $u) {
+    send_email($u['email'], $subject, $message);
+    $emails[] = $u['email'];
+}
+
+$stmt = $pdo->prepare('INSERT INTO email_broadcasts (admin_id, subject, message, sent_to) VALUES (?, ?, ?, ?)');
+$stmt->execute([$admin['id'], $subject, $message, implode(',', $emails)]);
+
+send_json(['message' => 'Emails sent']);
+?>

--- a/api/admin/dashboard_stats.php
+++ b/api/admin/dashboard_stats.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../../middleware/admin_auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$users = $pdo->query('SELECT COUNT(*) FROM users')->fetchColumn();
+$pending_deposits = $pdo->query("SELECT COUNT(*) FROM deposits WHERE status='pending'")->fetchColumn();
+$pending_withdrawals = $pdo->query("SELECT COUNT(*) FROM withdrawals WHERE status='pending'")->fetchColumn();
+
+send_json([
+    'users' => (int)$users,
+    'pending_deposits' => (int)$pending_deposits,
+    'pending_withdrawals' => (int)$pending_withdrawals
+]);
+?>

--- a/api/auth/login.php
+++ b/api/auth/login.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../config/cors.php';
+require_once __DIR__ . '/../../helpers/response.php';
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../helpers/token.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    send_json(['error' => 'Invalid JSON'], 400);
+}
+
+$username = $input['username'] ?? '';
+$password = $input['password'] ?? '';
+if (!$username || !$password) {
+    send_json(['error' => 'Missing credentials'], 400);
+}
+
+$stmt = $pdo->prepare('SELECT * FROM users WHERE username=? OR email=?');
+$stmt->execute([$username, $username]);
+$user = $stmt->fetch();
+if (!$user || !password_verify($password, $user['password'])) {
+    send_json(['error' => 'Invalid credentials'], 401);
+}
+
+$token = generate_token($user['id']);
+
+send_json(['token' => $token]);
+?>

--- a/api/auth/register.php
+++ b/api/auth/register.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../../config/cors.php';
+require_once __DIR__ . '/../../helpers/response.php';
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../helpers/token.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    send_json(['error' => 'Invalid JSON'], 400);
+}
+
+$full_name = $input['full_name'] ?? '';
+$username = $input['username'] ?? '';
+$email = $input['email'] ?? '';
+$password = $input['password'] ?? '';
+$referred_by = $input['referred_by'] ?? null;
+
+if (!$full_name || !$username || !$email || !$password) {
+    send_json(['error' => 'Missing fields'], 400);
+}
+
+// check unique username/email
+$stmt = $pdo->prepare('SELECT id FROM users WHERE username=? OR email=?');
+$stmt->execute([$username, $email]);
+if ($stmt->fetch()) {
+    send_json(['error' => 'User exists'], 409);
+}
+
+$hash = password_hash($password, PASSWORD_BCRYPT);
+$referral_code = bin2hex(random_bytes(5));
+
+$stmt = $pdo->prepare('INSERT INTO users (full_name, username, email, password, referral_code, referred_by) VALUES (?, ?, ?, ?, ?, ?)');
+$stmt->execute([$full_name, $username, $email, $hash, $referral_code, $referred_by]);
+$user_id = $pdo->lastInsertId();
+$token = generate_token($user_id);
+
+send_json(['token' => $token, 'user_id' => $user_id]);
+?>

--- a/api/deposits/history.php
+++ b/api/deposits/history.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$stmt = $pdo->prepare('SELECT * FROM deposits WHERE user_id=? ORDER BY created_at DESC');
+$stmt->execute([$user['id']]);
+$rows = $stmt->fetchAll();
+
+send_json(['deposits' => $rows]);
+?>

--- a/api/deposits/request.php
+++ b/api/deposits/request.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    send_json(['error' => 'Invalid JSON'], 400);
+}
+
+$amount = $input['amount'] ?? 0;
+$method = $input['method'] ?? '';
+if ($amount <= 0 || !$method) {
+    send_json(['error' => 'Invalid payload'], 400);
+}
+
+$stmt = $pdo->prepare('INSERT INTO deposits (user_id, amount, method, status) VALUES (?, ?, ?, "pending")');
+$stmt->execute([$user['id'], $amount, $method]);
+
+send_json(['message' => 'Deposit requested']);
+?>

--- a/api/referrals/earnings.php
+++ b/api/referrals/earnings.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../middleware/auth.php';
+require_once __DIR__ . '/../config/db.php';
+
+$stmt = $pdo->prepare('SELECT * FROM referral_earnings WHERE referrer_id=? ORDER BY created_at DESC');
+$stmt->execute([$user['id']]);
+$rows = $stmt->fetchAll();
+
+send_json(['earnings' => $rows]);
+?>

--- a/api/transactions/history.php
+++ b/api/transactions/history.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$stmt = $pdo->prepare('SELECT * FROM transactions WHERE userId=? ORDER BY date DESC');
+$stmt->execute([$user['id']]);
+$rows = $stmt->fetchAll();
+
+send_json(['transactions' => $rows]);
+?>

--- a/api/user/earnings.php
+++ b/api/user/earnings.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$stmt = $pdo->prepare('SELECT SUM(amount) AS total FROM referral_earnings WHERE referrer_id=?');
+$stmt->execute([$user['id']]);
+$total = $stmt->fetchColumn() ?: 0;
+
+send_json(['total_earnings' => $total]);
+?>

--- a/api/user/get_profile.php
+++ b/api/user/get_profile.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+
+unset($user['password']);
+unset($user['api_token']);
+
+send_json($user);
+?>

--- a/api/user/update.php
+++ b/api/user/update.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    send_json(['error' => 'Invalid JSON'], 400);
+}
+
+$full_name = $input['full_name'] ?? $user['full_name'];
+$email = $input['email'] ?? $user['email'];
+
+$stmt = $pdo->prepare('UPDATE users SET full_name=?, email=? WHERE id=?');
+$stmt->execute([$full_name, $email, $user['id']]);
+
+send_json(['message' => 'Profile updated']);
+?>

--- a/api/withdrawals/history.php
+++ b/api/withdrawals/history.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$stmt = $pdo->prepare('SELECT * FROM withdrawals WHERE user_id=? ORDER BY created_at DESC');
+$stmt->execute([$user['id']]);
+$rows = $stmt->fetchAll();
+
+send_json(['withdrawals' => $rows]);
+?>

--- a/api/withdrawals/request.php
+++ b/api/withdrawals/request.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__ . '/../../middleware/auth.php';
+require_once __DIR__ . '/../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    send_json(['error' => 'Invalid JSON'], 400);
+}
+
+$amount = $input['amount'] ?? 0;
+$wallet = $input['wallet_address'] ?? '';
+$method = $input['method'] ?? '';
+if ($amount <= 0 || !$wallet || !$method) {
+    send_json(['error' => 'Invalid payload'], 400);
+}
+
+$stmt = $pdo->prepare('INSERT INTO withdrawals (user_id, amount, wallet_address, method, status) VALUES (?, ?, ?, ?, "pending")');
+$stmt->execute([$user['id'], $amount, $wallet, $method]);
+
+send_json(['message' => 'Withdrawal requested']);
+?>

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,8 @@
+<?php
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Headers: Authorization, Content-Type');
+header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    exit;
+}
+?>

--- a/config/db.php
+++ b/config/db.php
@@ -1,0 +1,19 @@
+<?php
+$DB_HOST = 'localhost';
+$DB_NAME = 'siemensx';
+$DB_USER = 'root';
+$DB_PASS = '';
+$dsn = "mysql:host=$DB_HOST;dbname=$DB_NAME;charset=utf8mb4";
+
+try {
+    $pdo = new PDO($dsn, $DB_USER, $DB_PASS, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Database connection failed']);
+    exit;
+}
+?>

--- a/db.sql
+++ b/db.sql
@@ -1,0 +1,82 @@
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  full_name VARCHAR(100) NOT NULL,
+  username VARCHAR(100) UNIQUE NOT NULL,
+  email VARCHAR(150) UNIQUE NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  balance DECIMAL(12,2) DEFAULT 0,
+  profile_image VARCHAR(255) DEFAULT NULL,
+  referral_code VARCHAR(50) UNIQUE,
+  referred_by INT DEFAULT NULL,
+  api_token VARCHAR(255) DEFAULT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (referred_by) REFERENCES users(id)
+);
+
+CREATE TABLE admins (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(100) UNIQUE NOT NULL,
+  email VARCHAR(150) UNIQUE NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  api_token VARCHAR(255) DEFAULT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE deposits (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  amount DECIMAL(12,2) NOT NULL,
+  method VARCHAR(50) NOT NULL,
+  receipt_image VARCHAR(255) DEFAULT NULL,
+  status ENUM('pending','approved','rejected') DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE withdrawals (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  amount DECIMAL(12,2) NOT NULL,
+  wallet_address VARCHAR(255) NOT NULL,
+  method VARCHAR(50) NOT NULL,
+  status ENUM('pending','approved','rejected') DEFAULT 'pending',
+  processed_by INT DEFAULT NULL,
+  processed_at TIMESTAMP NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (processed_by) REFERENCES admins(id)
+);
+
+CREATE TABLE referral_earnings (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  referrer_id INT NOT NULL,
+  referred_user_id INT NOT NULL,
+  amount DECIMAL(12,2) NOT NULL,
+  description VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (referrer_id) REFERENCES users(id),
+  FOREIGN KEY (referred_user_id) REFERENCES users(id)
+);
+
+CREATE TABLE transactions (
+  transactionId INT AUTO_INCREMENT PRIMARY KEY,
+  action VARCHAR(100) NOT NULL,
+  credit VARCHAR(50),
+  debit VARCHAR(50),
+  balance VARCHAR(50),
+  beneId VARCHAR(50),
+  other VARCHAR(255),
+  userId INT NOT NULL,
+  date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (userId) REFERENCES users(id)
+);
+
+CREATE TABLE email_broadcasts (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  admin_id INT NOT NULL,
+  subject VARCHAR(255),
+  message TEXT,
+  sent_to TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (admin_id) REFERENCES admins(id)
+);

--- a/helpers/mail.php
+++ b/helpers/mail.php
@@ -1,0 +1,6 @@
+<?php
+function send_email($to, $subject, $message) {
+    // Placeholder for real mailing logic
+    return true;
+}
+?>

--- a/helpers/response.php
+++ b/helpers/response.php
@@ -1,0 +1,8 @@
+<?php
+function send_json($data, $status = 200) {
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($data);
+    exit;
+}
+?>

--- a/helpers/token.php
+++ b/helpers/token.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/response.php';
+
+function generate_token($user_id, $table = 'users') {
+    global $pdo;
+    $token = bin2hex(random_bytes(16));
+    $stmt = $pdo->prepare("UPDATE {$table} SET api_token=? WHERE id=?");
+    $stmt->execute([$token, $user_id]);
+    return $token;
+}
+
+function auth_user() {
+    global $pdo;
+    $auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    if (preg_match('/Bearer\s+(.*)$/i', $auth, $m)) {
+        $token = $m[1];
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE api_token=?');
+        $stmt->execute([$token]);
+        $user = $stmt->fetch();
+        if ($user) {
+            return $user;
+        }
+    }
+    return null;
+}
+
+function auth_admin() {
+    global $pdo;
+    $auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    if (preg_match('/Bearer\s+(.*)$/i', $auth, $m)) {
+        $token = $m[1];
+        $stmt = $pdo->prepare('SELECT * FROM admins WHERE api_token=?');
+        $stmt->execute([$token]);
+        $admin = $stmt->fetch();
+        if ($admin) {
+            return $admin;
+        }
+    }
+    return null;
+}
+?>

--- a/middleware/admin_auth.php
+++ b/middleware/admin_auth.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../config/cors.php';
+require_once __DIR__ . '/../helpers/response.php';
+require_once __DIR__ . '/../helpers/token.php';
+
+$admin = auth_admin();
+if (!$admin) {
+    send_json(['error' => 'Unauthorized'], 401);
+}
+?>

--- a/middleware/auth.php
+++ b/middleware/auth.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../config/cors.php';
+require_once __DIR__ . '/../helpers/response.php';
+require_once __DIR__ . '/../helpers/token.php';
+
+$user = auth_user();
+if (!$user) {
+    send_json(['error' => 'Unauthorized'], 401);
+}
+?>

--- a/uploads/profile_images/.htaccess
+++ b/uploads/profile_images/.htaccess
@@ -1,0 +1,2 @@
+php_flag engine off
+Options -Indexes

--- a/uploads/receipts/.htaccess
+++ b/uploads/receipts/.htaccess
@@ -1,0 +1,2 @@
+php_flag engine off
+Options -Indexes


### PR DESCRIPTION
## Summary
- document how to consume the backend endpoints in `API_INTEGRATION.md`
- link integration guide from README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaced9cf48327af2c0ff5e43343c4